### PR TITLE
Add minimum version_requirement for Puppet

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -23,5 +23,11 @@
         "operatingsystemrelease": ["12.04","14.04"]
       }
   ],
-  "dependencies": [ ]
+  "dependencies": [ ],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": ">= 3.8.7 < 5.0.0"
+    }
+  ]
 }


### PR DESCRIPTION
We currently only run automated tests against Puppet 3 latest and
therefore cannot guarantee that this module works as is expected with
earlier Puppet versions